### PR TITLE
sweetpea/primitives: fix #11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sweetpea",
-    version="0.1.0",
+    version="0.1.1",
     author="Annie Cherkaev, Ben Draut",
     author_email="annie.cherk@gmail.com, drautb@cs.utah.edu",
     description="A language for synthesizing randomized experimental designs",

--- a/sweetpea/primitives.py
+++ b/sweetpea/primitives.py
@@ -97,7 +97,7 @@ class Level:
     #       factors are responsible for registering themselves with their
     #       levels. Perhaps factors could be the only way to create levels?
     #: The factor to which this level belongs.
-    factor: Factor = field(init=False)
+    factor: Factor = field(init=False, repr=False)
 
     # NOTE: Because of the way dataclasses work, a base class (e.g., `Level`)
     #       cannot provide an attribute with a default value if a subclass


### PR DESCRIPTION
The issue was caused by attempting to print the `Level.factor` value in
`Level.__repr__` even when no `Level.factor` had been set.